### PR TITLE
Disable button gradient setting

### DIFF
--- a/kstyle/breeze.kcfg
+++ b/kstyle/breeze.kcfg
@@ -179,6 +179,11 @@
       <default>true</default>
     </entry>
 
+    <!-- button gradient -->
+    <entry name="ButtonGradient" type="Bool">
+      <default>true</default>
+    </entry>
+
     <!-- window dragging -->
     <entry name="WindowDragMode" type="Enum">
       <choices>

--- a/kstyle/breezehelper.cpp
+++ b/kstyle/breezehelper.cpp
@@ -621,6 +621,7 @@ namespace Breeze
         bool flat = stateProperties.value("flat");
         bool defaultButton = stateProperties.value("defaultButton");
         bool hasNeutralHighlight = stateProperties.value("hasNeutralHighlight");
+		bool gradient = stateProperties.value("gradient");
 
         // don't render background if flat and not hovered, down, checked, or given visual focus
         if (flat && !(hovered || down || checked || visualFocus)
@@ -698,7 +699,7 @@ namespace Breeze
         }
 
         // Gradient
-        if (!(flat || down || hovered || checked) && enabled) {
+        if (!(flat || down || hovered || checked) && gradient && enabled) {
             QLinearGradient bgGradient(frameRect.topLeft(), frameRect.bottomLeft());
             bgGradient.setColorAt(0, KColorUtils::mix(bgBrush.color(), Qt::white, 0.03125));
             bgGradient.setColorAt(0.5, bgBrush.color());

--- a/kstyle/breezehelper.cpp
+++ b/kstyle/breezehelper.cpp
@@ -621,7 +621,7 @@ namespace Breeze
         bool flat = stateProperties.value("flat");
         bool defaultButton = stateProperties.value("defaultButton");
         bool hasNeutralHighlight = stateProperties.value("hasNeutralHighlight");
-		bool gradient = stateProperties.value("gradient");
+        bool gradient = stateProperties.value("gradient");
 
         // don't render background if flat and not hovered, down, checked, or given visual focus
         if (flat && !(hovered || down || checked || visualFocus)
@@ -833,7 +833,7 @@ namespace Breeze
 
         }
 
-        
+
     }
 
     //______________________________________________________________________________
@@ -1065,7 +1065,7 @@ namespace Breeze
 
         QRectF markerRect;
         markerRect = frameRect.adjusted( 6, 6, -6, -6 );
-        
+
         qreal adjustFactor;
 
         // mark
@@ -1108,7 +1108,7 @@ namespace Breeze
             painter->drawRoundedRect( baseRect, radius, radius );
         }
 
-        
+
     }
 
     //______________________________________________________________________________
@@ -1135,7 +1135,7 @@ namespace Breeze
 
             const QPen bgPen( fg, penWidth, Qt::SolidLine, Qt::RoundCap );
             const QPen fgPen( KColorUtils::overlayColors( bg, alphaColor( fg, 0.5) ), penWidth - 2, Qt::SolidLine, Qt::RoundCap );
-            
+
             // setup pen
             if( angleSpan != 0 )
             {
@@ -1211,7 +1211,7 @@ namespace Breeze
             painter->drawRoundedRect( baseRect, radius, radius );
         }
 
-        
+
     }
 
 
@@ -1288,7 +1288,7 @@ namespace Breeze
         painter->setBrush( KColorUtils::overlayColors(bg, alphaColor(fg, 0.5)) );
         painter->drawRoundedRect( strokedRect(baseRect), radius, radius );
 
-        
+
     }
 
     void Helper::renderScrollBarGroove(
@@ -1314,7 +1314,7 @@ namespace Breeze
             painter->drawRoundedRect( strokedRect(baseRect), radius, radius );
         }
 
-        
+
     }
 
 
@@ -1458,7 +1458,7 @@ namespace Breeze
     //______________________________________________________________________________
     void Helper::renderDecorationButton( QPainter* painter, const QRect& rect, const QColor& foregroundColor, ButtonType buttonType, bool inverted, bool paintBackground, const QColor& backgroundColor, const QColor& outlineColor ) const
     {
-        
+
         painter->save();
         painter->setViewport( rect );
         painter->setWindow( 0, 0, 18, 18 );
@@ -1468,17 +1468,17 @@ namespace Breeze
         QPen pen;
         pen.setCapStyle( Qt::RoundCap );
         pen.setJoinStyle( Qt::RoundJoin );
-        
+
         if( inverted ) paintBackground = true;
         if( paintBackground )
         {
             // render circle or square background
             if( outlineColor.isValid() ) painter->setPen( outlineColor );
             else painter->setPen( Qt::NoPen );
-            
+
             if( inverted ) painter->setBrush( foregroundColor );
             else painter->setBrush( backgroundColor );
-            
+
             if( decorationConfig()->buttonShape() ==  InternalSettings::EnumButtonShape::ShapeFullHeightRectangle
                 || decorationConfig()->buttonShape() ==  InternalSettings::EnumButtonShape::ShapeSmallSquare
                 || decorationConfig()->buttonShape() ==  InternalSettings::EnumButtonShape::ShapeSmallRoundedSquare
@@ -1489,8 +1489,8 @@ namespace Breeze
                 if( outlineColor.isValid() ) painter->drawEllipse( QRectF( 1, 1, 16, 16 ) ); // have to shrink outlined circle otherwise it gets clipped
                 else painter->drawEllipse( QRectF( 0, 0, 18, 18 ) );
             }
-            
-            
+
+
             if( inverted ){
                 // take out the inner part
                 painter->setCompositionMode( QPainter::CompositionMode_DestinationOut );
@@ -1513,10 +1513,10 @@ namespace Breeze
 
         pen.setWidthF( PenWidth::Symbol*qMax(1.0, 18.0/rect.width() ) );
         painter->setPen(pen);
-        
+
         std::unique_ptr<RenderDecorationButtonIcon18By18> iconRenderer;
         iconRenderer = RenderDecorationButtonIcon18By18::factory( decorationConfig(), painter, true );
-        
+
         switch( buttonType )
         {
             case ButtonClose:
@@ -1569,7 +1569,7 @@ namespace Breeze
     void Helper::renderEllipseShadow( QPainter* painter, const QRectF& rect, const QColor& color ) const
     {
         if( !color.isValid() ) return;
-        
+
         painter->save();
 
         // Clipping does not improve performance here
@@ -1577,22 +1577,22 @@ namespace Breeze
         qreal adjustment = 0.5 * PenWidth::Shadow; // Adjust for the pen
 
         qreal radius = rect.width() / 2 - adjustment;
-        
+
         /* The right side is offset by +0.5 for the visible part of the shadow.
          * The other sides are offset by +0.5 or -0.5 because of the pen.
          */
         QRectF shadowRect = rect.adjusted( adjustment, adjustment, adjustment, -adjustment );
-        
+
         painter->translate( rect.center() );
         painter->rotate( 45 );
         painter->translate( -rect.center() );
         painter->setPen( color );
         painter->setBrush( Qt::NoBrush );
         painter->drawRoundedRect( shadowRect, radius, radius );
-        
+
         painter->restore();
     }
-    
+
     //______________________________________________________________________________
     bool Helper::isX11()
     {

--- a/kstyle/breezestyle.cpp
+++ b/kstyle/breezestyle.cpp
@@ -2551,11 +2551,11 @@ namespace Breeze
         // cast option and check
         const auto sliderOption( qstyleoption_cast<const QStyleOptionSlider*>( option ) );
         if( !sliderOption ) return ParentStyleClass::subControlRect( CC_ScrollBar, option, subControl, widget );
-        
+
         //bools marking the extremities of slider position
         bool sliderAtMin = ( sliderOption->sliderPosition == sliderOption->minimum );
         bool sliderAtMax = ( sliderOption->sliderPosition == sliderOption->maximum );
-        
+
         // get relevant state
         const State& state( option->state );
         const bool horizontal( state & State_Horizontal );
@@ -2573,10 +2573,10 @@ namespace Breeze
             {
                 auto topRect = visualRect( option, scrollBarInternalSubControlRect( option, SC_ScrollBarSubLine ) );
                 auto bottomRect = visualRect( option, scrollBarInternalSubControlRect( option, SC_ScrollBarAddLine ) );
-                
+
                 QPoint topLeftCorner;
                 QPoint botRightCorner;
-                
+
                 bool enlargeOverSubPage = false;
                 bool enlargeOverAddPage = false;
                 if( autoHideArrows && (sliderOption->minimum == sliderOption->maximum) ){
@@ -2595,7 +2595,7 @@ namespace Breeze
                         if( enlargeOverSubPage ) topLeftCorner = QPoint ( topRect.left() + Metrics::ScrollBar_TopBottomMargins, topRect.top() );
                         else topLeftCorner  = QPoint( topRect.right() + StyleConfigData::scrollBarTopTwoButtonSpacing(), topRect.top() );
                     }
-                    
+
                     if( _addLineButtons == ScrollBarButtonType::NoButton ) {
                         botRightCorner = QPoint( bottomRect.right() - Metrics::ScrollBar_TopBottomMargins, topRect.bottom() );
                     } else if( _addLineButtons == ScrollBarButtonType::SingleButton ){
@@ -2607,7 +2607,7 @@ namespace Breeze
                     }
 
                 } else {
-                    
+
                     if( _subLineButtons == ScrollBarButtonType::NoButton ) {
                         topLeftCorner  = QPoint( topRect.left(),  topRect.top() + Metrics::ScrollBar_TopBottomMargins );
                     } else if( _subLineButtons == ScrollBarButtonType::SingleButton ) {
@@ -2617,7 +2617,7 @@ namespace Breeze
                         if( enlargeOverSubPage ) topLeftCorner = QPoint ( topRect.left(), topRect.top() + Metrics::ScrollBar_TopBottomMargins );
                         else topLeftCorner  = QPoint( topRect.left(),  topRect.bottom() + StyleConfigData::scrollBarTopTwoButtonSpacing() );
                     }
-                    
+
                     if( _addLineButtons == ScrollBarButtonType::NoButton ) {
                         botRightCorner = QPoint( topRect.right(), bottomRect.bottom() - Metrics::ScrollBar_TopBottomMargins );
                     } else if( _addLineButtons == ScrollBarButtonType::SingleButton ) {
@@ -2634,8 +2634,8 @@ namespace Breeze
                 return visualRect( option, QRect( topLeftCorner, botRightCorner )  );
 
             }
-            
-            
+
+
 
             case SC_ScrollBarSlider:
             {
@@ -2657,16 +2657,16 @@ namespace Breeze
 
                 space -= sliderSize;
                 if( space <= 0 ) return groove;
-                
+
                 // determines whether to enlarge the slider over the area occupied by the arrows when slider is at extremities and mouse is not over
                 bool enlargeOverSubPage = false;
                 bool enlargeOverAddPage = false;
                 if( _subLineButtons != ScrollBarButtonType::NoButton && sliderAtMin && !mouseOver && autoHideArrows )  enlargeOverSubPage = true;
                 if( _addLineButtons != ScrollBarButtonType::NoButton && sliderAtMax && !mouseOver && autoHideArrows )  enlargeOverAddPage = true;
-                
+
                 int pos = qRound( qreal( sliderOption->sliderPosition - sliderOption->minimum )/ ( sliderOption->maximum - sliderOption->minimum )*space );
                 if( sliderOption->upsideDown ) pos = space - pos;
-                
+
                 //return the slider rect, accounting for any enlargement of slider at extremities
                 if( horizontal ) {
                     if( enlargeOverSubPage ) {
@@ -2680,12 +2680,12 @@ namespace Breeze
                         else if (_addLineButtons == ScrollBarButtonType::DoubleButton ) enlargeToBottomRectXBy = bottomRect.right() - groove.right() - Metrics::ScrollBar_TopBottomMargins;
                         return visualRect( option, QRect( groove.left() + pos, groove.top(), sliderSize + enlargeToBottomRectXBy, groove.height() ) );
                     } else return visualRect( option, QRect( groove.left() + pos, groove.top(), sliderSize, groove.height() ) );
-                    
+
                 } else {
                     if( enlargeOverSubPage ) {
                         int enlargeToTopRectYPos = topRect.top();
                         if (_subLineButtons == ScrollBarButtonType::SingleButton ) enlargeToTopRectYPos = topRect.top() + Metrics::ScrollBar_TopBottomMargins;
-                        else if (_subLineButtons == ScrollBarButtonType::DoubleButton ) enlargeToTopRectYPos = topRect.top() + Metrics::ScrollBar_TopBottomMargins; 
+                        else if (_subLineButtons == ScrollBarButtonType::DoubleButton ) enlargeToTopRectYPos = topRect.top() + Metrics::ScrollBar_TopBottomMargins;
                         return visualRect( option, QRect( groove.left(), enlargeToTopRectYPos + pos, groove.width(), sliderSize + ( groove.top() - enlargeToTopRectYPos ) ) );
                     } else if (enlargeOverAddPage ) {
                         int enlargeToBottomRectYBy = 0;
@@ -2729,7 +2729,7 @@ namespace Breeze
     bool Style::scrollBarAutoHideArrowsException( const QWidget* widget ) const
     {
         bool exception = false;
-        
+
         if( widget ){
             std::array<const char*,1> exceptionClassNames = {"KateScrollBar"};
             for( unsigned i=0; i < exceptionClassNames.size(); i++ ){
@@ -2739,17 +2739,17 @@ namespace Breeze
                 }
             }
         }
-        
+
         return exception;
     }
-    
+
     bool Style::shouldAutoHideArrows( const QWidget* widget ) const
     {
         if( StyleConfigData::animationsEnabled() && StyleConfigData::scrollBarAutoHideArrows() && !scrollBarAutoHideArrowsException(widget) )
             return true;
         else return false;
     }
-    
+
     //___________________________________________________________________________________________________________________
     QRect Style::dialSubControlRect( const QStyleOptionComplex* option, SubControl subControl, const QWidget* widget ) const
     {
@@ -3833,7 +3833,7 @@ namespace Breeze
         stateProperties["hasMenu"] = hasMenu;
         stateProperties["defaultButton"] = defaultButton;
         stateProperties["hasNeutralHighlight"] = hasNeutralHighlight;
-		stateProperties["gradient"] = StyleConfigData::buttonGradient();
+        stateProperties["gradient"] = StyleConfigData::buttonGradient();
 
         _helper->renderButtonFrame(painter, option->rect, option->palette, stateProperties, bgAnimation, penAnimation);
 
@@ -3999,7 +3999,7 @@ namespace Breeze
         _helper->renderMenuFrame( painter, option->rect, background, outline, hasAlpha, isTopMenu );
 
         painter->restore();
-        
+
         return true;
 
     }
@@ -4208,7 +4208,7 @@ namespace Breeze
         stateProperties["checked"] = checked;
         stateProperties["flat"] = flat;
         stateProperties["hasNeutralHighlight"] = hasNeutralHighlight;
-	    stateProperties["gradient"] = StyleConfigData::buttonGradient();
+        stateProperties["gradient"] = StyleConfigData::buttonGradient();
 
 
 	    _helper->renderButtonFrame(painter, baseRect, option->palette, stateProperties, bgAnimation, penAnimation);
@@ -4992,17 +4992,17 @@ namespace Breeze
             // normal separator
             if( menuItemOption->text.isEmpty() && menuItemOption->icon.isNull() )
             {
-                
+
                 auto color( _helper->separatorColor( palette ) );
                 QRect copy( rect );
-                
-                if( StyleConfigData::menuOpacity() < 100 ) 
+
+                if( StyleConfigData::menuOpacity() < 100 )
                 {
                     color = _helper->alphaColor( palette.color( QPalette::WindowText ), 0.25 ) ;
                     // don`t overlap with menu border
                     copy.adjust( 1, 0, -1, 0 );
                 }
-                
+
                 _helper->renderSeparator( painter, copy, color );
                 return true;
 
@@ -5421,7 +5421,7 @@ namespace Breeze
         // cast option and check
         const auto sliderOption( qstyleoption_cast<const QStyleOptionSlider*>( option ) );
         if( !sliderOption ) return true;
-        
+
         if( shouldAutoHideArrows(widget) && (sliderOption->minimum == sliderOption->maximum) ) return true;
 
         const State& state( option->state );
@@ -5485,7 +5485,7 @@ namespace Breeze
             {
                 if( reverseLayout ) _helper->renderArrow( painter, rect, color, ArrowLeft );
                 else _helper->renderArrow( painter, rect, color, ArrowRight );
-            } 
+            }
             else _helper->renderArrow( painter, rect, color, ArrowDown );
 
         }
@@ -5504,7 +5504,7 @@ namespace Breeze
         // cast option and check
         const auto sliderOption( qstyleoption_cast<const QStyleOptionSlider*>( option ) );
         if( !sliderOption ) return true;
-        
+
         if( shouldAutoHideArrows(widget) && (sliderOption->minimum == sliderOption->maximum) ) return true;
 
         const State& state( option->state );
@@ -6644,10 +6644,10 @@ namespace Breeze
                 stateProperties["down"] = down || checked;
                 stateProperties["flat"] = flat;
                 stateProperties["hasNeutralHighlight"] = hasNeutralHighlight;
-	            stateProperties["gradient"] = StyleConfigData::buttonGradient();
+                stateProperties["gradient"] = StyleConfigData::buttonGradient();
 
 
-	            _helper->renderButtonFrame(painter, option->rect, option->palette, stateProperties, bgAnimation, penAnimation);
+                _helper->renderButtonFrame(painter, option->rect, option->palette, stateProperties, bgAnimation, penAnimation);
             }
         }
 
@@ -7311,9 +7311,9 @@ namespace Breeze
         if( widget ) widgetMouseOver = widget->underMouse();
         // in case this QStyle is used by QQuickControls QStyle wrapper
         else if( option->styleObject ) widgetMouseOver = option->styleObject->property("hover").toBool();
-        
+
         bool autoHideArrows = shouldAutoHideArrows(widget);
-        
+
         // check enabled state
         const bool enabled( option->state & State_Enabled );
         if( !enabled ) {
@@ -7536,13 +7536,13 @@ namespace Breeze
         const bool withTrafficLights( _helper->decorationConfig()->backgroundColors() == InternalSettings::EnumBackgroundColors::ColorsAccentWithTrafficLights );
 
         palette.setCurrentColorGroup( QPalette::Active );
-        
+
         std::shared_ptr<SystemButtonColors> decorationButtonAccentColors = ColorTools::getSystemButtonColors( palette );
-        
+
         const QColor base( palette.color( QPalette::WindowText ) );
         const QColor selected( _helper->titleBarTextColor( true ) );
-        
-        
+
+
         //foreground colours
         QColor offHoverForeground;
         QColor onFocusForeground;
@@ -7550,28 +7550,28 @@ namespace Breeze
         QColor offSelectedForeground;
         QColor offForeground;
         QColor disabledForeground;
-        
+
         //background colours
         QColor offInvertedNormalStateBackground;
         QColor disabledInvertedNormalStateBackground;
         QColor offSelectedInvertedNormalStateBackground;
         QColor offHoverBackground;
         QColor onFocusBackground;
-        
+
         //outline colours
         QColor outline;
-        
+
         if( _helper->decorationConfig()->backgroundColors() == InternalSettings::EnumBackgroundColors::ColorsTitlebarText ){
-            
+
             if( _helper->decorationConfig()->translucentButtonBackgrounds() ){
                 onFocusForeground = buttonType == ButtonClose ? Qt::GlobalColor::white : KColorUtils::mix( palette.color( QPalette::Window ), base, 0.8 );
                 onFocusSelectedForeground = buttonType == ButtonClose ? Qt::GlobalColor::white : selected;
                 offSelectedForeground = selected;
-                
+
                 offHoverForeground = buttonType == ButtonClose ? Qt::GlobalColor::white : KColorUtils::mix( palette.color( QPalette::Window ), base, 0.7 );
                 offForeground = KColorUtils::mix( palette.color( QPalette::Window ), base,  0.5 );
                 disabledForeground = KColorUtils::mix( palette.color( QPalette::Window ), base, 0.2 );
-                
+
                 //for translucent, background colours also need to be defined
                 offInvertedNormalStateBackground = ColorTools::alphaMix( base,  0.15 );
                 disabledInvertedNormalStateBackground = ColorTools::alphaMix( base, 0.07 );
@@ -7581,19 +7581,19 @@ namespace Breeze
             } else {
                 //for non-translucent using the titlebar text colour, it is a special case in the later logic where the foreground colour is inverted to create the background
                 onFocusForeground = buttonType == ButtonClose ? decorationButtonAccentColors->negativeSaturated : KColorUtils::mix( palette.color( QPalette::Window ), base,  0.7 );
-                onFocusSelectedForeground = buttonType == ButtonClose ? decorationButtonAccentColors->negativeSaturated : selected; 
+                onFocusSelectedForeground = buttonType == ButtonClose ? decorationButtonAccentColors->negativeSaturated : selected;
                 if( isAlwaysShownCloseButton ){
                     offSelectedForeground = _helper->decorationConfig()->redAlwaysShownClose() ? decorationButtonAccentColors->negative : selected;
                 } else offSelectedForeground = selected;
-                
+
                 offHoverForeground = buttonType == ButtonClose ? decorationButtonAccentColors->negative : KColorUtils::mix( palette.color( QPalette::Window ), base,  0.5 );
                 offForeground = KColorUtils::mix( palette.color( QPalette::Window ), base,  0.5 );
                 disabledForeground = KColorUtils::mix( palette.color( QPalette::Window ), base, 0.2 );
                 onFocusBackground = onFocusForeground; //used only for setting outline colour
             }
         } else {
-            //Colours used if Accent colours            
-            
+            //Colours used if Accent colours
+
             if( _helper->decorationConfig()->translucentButtonBackgrounds() ){
                 onFocusForeground = buttonType == ButtonClose ? Qt::GlobalColor::white : KColorUtils::mix( palette.color( QPalette::Window ), base, 0.8 );
                 onFocusSelectedForeground = buttonType == ButtonClose ? Qt::GlobalColor::white : selected;
@@ -7601,7 +7601,7 @@ namespace Breeze
                 offForeground = KColorUtils::mix( palette.color( QPalette::Window ), base,  0.5 );
                 disabledForeground = KColorUtils::mix( palette.color( QPalette::Window ), base,  0.2 );
                 offSelectedForeground = selected;
-                
+
                 offInvertedNormalStateBackground = ColorTools::alphaMix( base,  0.15 );
                 disabledInvertedNormalStateBackground = ColorTools::alphaMix( base, 0.07 );
                 offSelectedInvertedNormalStateBackground = ( _helper->decorationConfig()->redAlwaysShownClose() ) ? decorationButtonAccentColors->negativeReducedOpacityBackground : decorationButtonAccentColors->buttonReducedOpacityBackground;
@@ -7612,14 +7612,14 @@ namespace Breeze
                 offForeground = KColorUtils::mix( palette.color( QPalette::Window ), base,  0.5 );
                 disabledForeground = KColorUtils::mix( palette.color( QPalette::Window ), base,  0.2 );
                 offSelectedForeground = selected;
-                
+
                 offInvertedNormalStateBackground = KColorUtils::mix( palette.color( QPalette::Window ), base,  0.2 );
                 disabledInvertedNormalStateBackground = KColorUtils::mix( palette.color( QPalette::Window ), base,  0.07);
                 offSelectedInvertedNormalStateBackground = ( _helper->decorationConfig()->redAlwaysShownClose() ) ? decorationButtonAccentColors->negative : decorationButtonAccentColors->buttonHover;
             }
-            
-            
-            
+
+
+
             //hover and focus background colours
             switch ( buttonType ) {
                 case ButtonClose:
@@ -7663,24 +7663,24 @@ namespace Breeze
                         onFocusBackground = decorationButtonAccentColors->buttonFocus;
                     }
             }
-            
+
         }
-        
-        
+
+
         if( _helper->decorationConfig()->alwaysShowIconHighlightUsing() == InternalSettings::EnumAlwaysShowIconHighlightUsing::AlwaysShowIconHighlightUsingBackgroundAndOutline
                 //&& !isAlwaysShownCloseButton
         ){
             outline = onFocusBackground;
         }
-        
-        const bool setInvert( 
-        
-            (( _helper->decorationConfig()->backgroundColors() == InternalSettings::EnumBackgroundColors::ColorsTitlebarText )
-                && ( !_helper->decorationConfig()->translucentButtonBackgrounds() ) 
-            )
-        ); 
 
-        // convenience class to map color to icon mode      
+        const bool setInvert(
+
+            (( _helper->decorationConfig()->backgroundColors() == InternalSettings::EnumBackgroundColors::ColorsTitlebarText )
+                && ( !_helper->decorationConfig()->translucentButtonBackgrounds() )
+            )
+        );
+
+        // convenience class to map color to icon mode
         struct IconData
         {
             QIcon::Mode _mode;
@@ -7692,7 +7692,7 @@ namespace Breeze
             QColor _outlineColor;
         };
 
-        // map colors to icon states      
+        // map colors to icon states
         const QList<IconData> iconTypes =
         {
             // state off icons
@@ -7706,7 +7706,7 @@ namespace Breeze
             { QIcon::Selected, QIcon::On, onFocusSelectedForeground, setInvert, true, onFocusBackground, outline },
             { QIcon::Active, QIcon::On, onFocusForeground, setInvert, true, onFocusBackground, outline },
             { QIcon::Disabled, QIcon::On, disabledForeground, setInvert&&isAlwaysShownCloseButton, isAlwaysShownCloseButton, disabledInvertedNormalStateBackground, QColor() }
-        
+
         };
 
         // default icon sizes
@@ -7714,7 +7714,7 @@ namespace Breeze
 
         // output icon
         QIcon icon;
-        
+
         foreach( const IconData& iconData, iconTypes )
         {
 
@@ -7735,7 +7735,7 @@ namespace Breeze
             }
 
         }
-        
+
         return icon;
 
     }

--- a/kstyle/breezestyle.cpp
+++ b/kstyle/breezestyle.cpp
@@ -3833,6 +3833,7 @@ namespace Breeze
         stateProperties["hasMenu"] = hasMenu;
         stateProperties["defaultButton"] = defaultButton;
         stateProperties["hasNeutralHighlight"] = hasNeutralHighlight;
+		stateProperties["gradient"] = StyleConfigData::buttonGradient();
 
         _helper->renderButtonFrame(painter, option->rect, option->palette, stateProperties, bgAnimation, penAnimation);
 
@@ -3879,8 +3880,10 @@ namespace Breeze
         stateProperties["checked"] = checked;
         stateProperties["flat"] = flat;
         stateProperties["hasNeutralHighlight"] = hasNeutralHighlight;
+	    stateProperties["gradient"] = StyleConfigData::buttonGradient();
 
-        _helper->renderButtonFrame(painter, baseRect, option->palette, stateProperties, bgAnimation, penAnimation);
+
+	    _helper->renderButtonFrame(painter, baseRect, option->palette, stateProperties, bgAnimation, penAnimation);
         if (painter->hasClipping()) {
             painter->setClipping(false);
         }
@@ -4205,8 +4208,10 @@ namespace Breeze
         stateProperties["checked"] = checked;
         stateProperties["flat"] = flat;
         stateProperties["hasNeutralHighlight"] = hasNeutralHighlight;
+	    stateProperties["gradient"] = StyleConfigData::buttonGradient();
 
-        _helper->renderButtonFrame(painter, baseRect, option->palette, stateProperties, bgAnimation, penAnimation);
+
+	    _helper->renderButtonFrame(painter, baseRect, option->palette, stateProperties, bgAnimation, penAnimation);
 
         QRectF frameRect = _helper->strokedRect(_helper->shadowedRect(baseRect));
 
@@ -6639,8 +6644,10 @@ namespace Breeze
                 stateProperties["down"] = down || checked;
                 stateProperties["flat"] = flat;
                 stateProperties["hasNeutralHighlight"] = hasNeutralHighlight;
+	            stateProperties["gradient"] = StyleConfigData::buttonGradient();
 
-                _helper->renderButtonFrame(painter, option->rect, option->palette, stateProperties, bgAnimation, penAnimation);
+
+	            _helper->renderButtonFrame(painter, option->rect, option->palette, stateProperties, bgAnimation, penAnimation);
             }
         }
 

--- a/kstyle/config/breezestyleconfig.cpp
+++ b/kstyle/config/breezestyleconfig.cpp
@@ -48,6 +48,7 @@ namespace Breeze
         load();
 
         connect( _tabBarDrawCenteredTabs, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
+        connect( _buttonGradient, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _toolBarDrawItemSeparator, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _viewDrawFocusIndicator, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
         connect( _dockWidgetDrawFrame, &QAbstractButton::toggled, this, &StyleConfig::updateChanged );
@@ -80,6 +81,7 @@ namespace Breeze
     void StyleConfig::save()
     {
         StyleConfigData::setTabBarDrawCenteredTabs( _tabBarDrawCenteredTabs->isChecked() );
+        StyleConfigData::setButtonGradient( _buttonGradient->isChecked() );
         StyleConfigData::setToolBarDrawItemSeparator( _toolBarDrawItemSeparator->isChecked() );
         StyleConfigData::setViewDrawFocusIndicator( _viewDrawFocusIndicator->isChecked() );
         StyleConfigData::setDockWidgetDrawFrame( _dockWidgetDrawFrame->isChecked() );
@@ -134,6 +136,7 @@ namespace Breeze
 
         // check if any value was modified
         if( _tabBarDrawCenteredTabs->isChecked() != StyleConfigData::tabBarDrawCenteredTabs() ) modified = true;
+        else if( _buttonGradient->isChecked() != StyleConfigData::buttonGradient() ) modified = true;
         else if( _toolBarDrawItemSeparator->isChecked() != StyleConfigData::toolBarDrawItemSeparator() ) modified = true;
         else if( _viewDrawFocusIndicator->isChecked() != StyleConfigData::viewDrawFocusIndicator() ) modified = true;
         else if( _dockWidgetDrawFrame->isChecked() != StyleConfigData::dockWidgetDrawFrame() ) modified = true;
@@ -165,6 +168,7 @@ namespace Breeze
     {
 
         _tabBarDrawCenteredTabs->setChecked( StyleConfigData::tabBarDrawCenteredTabs() );
+        _buttonGradient->setChecked( StyleConfigData::buttonGradient() );
         _toolBarDrawItemSeparator->setChecked( StyleConfigData::toolBarDrawItemSeparator() );
         _viewDrawFocusIndicator->setChecked( StyleConfigData::viewDrawFocusIndicator() );
         _dockWidgetDrawFrame->setChecked( StyleConfigData::dockWidgetDrawFrame() );

--- a/kstyle/config/ui/breezestyleconfig.ui
+++ b/kstyle/config/ui/breezestyleconfig.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>631</width>
+    <width>667</width>
     <height>482</height>
    </rect>
   </property>
@@ -39,144 +39,7 @@
        <string>General</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0" colspan="2">
-        <widget class="QCheckBox" name="_tabBarDrawCenteredTabs">
-         <property name="text">
-          <string>Centre tabbar tabs</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0" colspan="2">
-        <widget class="QLabel" name="_mnemonicsLabel">
-         <property name="text">
-          <string>&amp;Keyboard accelerators visibility:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-         <property name="buddy">
-          <cstring>_mnemonicsMode</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0" rowspan="3" colspan="3">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>60</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="7" column="2" colspan="3">
-        <widget class="QComboBox" name="_mnemonicsMode">
-         <item>
-          <property name="text">
-           <string>Always Hide Keyboard Accelerators</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Show Keyboard Accelerators When Needed</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Always Show Keyboard Accelerators</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="7" column="5">
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>100</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="8" column="2" colspan="3">
-        <widget class="QComboBox" name="_windowDragMode">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <item>
-          <property name="text">
-           <string>Drag windows from titlebar only</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Drag windows from titlebar, menubar and toolbars</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Drag windows from all empty areas</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="8" column="0" colspan="2">
-        <widget class="QLabel" name="_windowDragLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>W&amp;indows' drag mode:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-         <property name="buddy">
-          <cstring>_windowDragMode</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="3">
-        <widget class="QCheckBox" name="_splitterProxyEnabled">
-         <property name="text">
-          <string>Enable extended resize handles</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0" colspan="2">
-        <widget class="QCheckBox" name="_viewDrawFocusIndicator">
-         <property name="text">
-          <string>Draw focus indicator in lists</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="2">
-        <widget class="QCheckBox" name="_sliderDrawTickMarks">
-         <property name="text">
-          <string>Draw slider tick marks</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0" rowspan="2" colspan="3">
-        <widget class="QCheckBox" name="_toolBarDrawItemSeparator">
-         <property name="text">
-          <string>Draw toolbar item separators</string>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0" colspan="6">
+       <item row="14" column="0" colspan="6">
         <layout class="QGridLayout" name="gridLayout_4">
          <item row="1" column="2">
           <spacer name="horizontalSpacer_7">
@@ -281,6 +144,150 @@
           </layout>
          </item>
         </layout>
+       </item>
+       <item row="10" column="0" rowspan="3" colspan="3">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>60</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="9" column="2" colspan="3">
+        <widget class="QComboBox" name="_windowDragMode">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <item>
+          <property name="text">
+           <string>Drag windows from titlebar only</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Drag windows from titlebar, menubar and toolbars</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Drag windows from all empty areas</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="7" column="0" colspan="3">
+        <widget class="QCheckBox" name="_splitterProxyEnabled">
+         <property name="text">
+          <string>Enable extended resize handles</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="2">
+        <widget class="QLabel" name="_mnemonicsLabel">
+         <property name="text">
+          <string>&amp;Keyboard accelerators visibility:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>_mnemonicsMode</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="2" colspan="3">
+        <widget class="QComboBox" name="_mnemonicsMode">
+         <item>
+          <property name="text">
+           <string>Always Hide Keyboard Accelerators</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Show Keyboard Accelerators When Needed</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Always Show Keyboard Accelerators</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="2">
+        <widget class="QCheckBox" name="_sliderDrawTickMarks">
+         <property name="text">
+          <string>Draw slider tick marks</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <widget class="QCheckBox" name="_viewDrawFocusIndicator">
+         <property name="text">
+          <string>Draw focus indicator in lists</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0" colspan="2">
+        <widget class="QLabel" name="_windowDragLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>W&amp;indows' drag mode:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>_windowDragMode</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QCheckBox" name="_tabBarDrawCenteredTabs">
+         <property name="text">
+          <string>Centre tabbar tabs</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="5">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>100</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="0" rowspan="2" colspan="3">
+        <widget class="QCheckBox" name="_toolBarDrawItemSeparator">
+         <property name="text">
+          <string>Draw toolbar item separators</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="_buttonGradient">
+         <property name="text">
+          <string>Show button gradient effect</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
Added an option to settings that disables button gradient effect from any application style buttons. I've tested it on my own machine and it works.

Note: First time I've worked on any Qt/KDE related code, do tell me about any issues and I'll fix them! :)

It also seems that my linter was a bit enthusiastic in the 39856170a42f85b91ba3e0a462b15a2cfd24d110 commit (where I fixed some indentations), so see c4b9cf3b34c88e4f833bb521ede21d4400ceafaf for the changes.